### PR TITLE
Add beq and eeq commands

### DIFF
--- a/elegantnote.cls
+++ b/elegantnote.cls
@@ -363,7 +363,10 @@
 % \let\pi\relax
 % \DeclareMathSymbol{\pi}{\mathord}{CMletters}{"19}
 
-
+\newcommand{\beq}{\begin{equation}}
+\newcommand{\eeq}{\end{equation}}
+\newcommand{\bequ}{\begin{equation*}}
+\newcommand{\eequ}{\end{equation*}}
 
 \lstset{basicstyle=\scriptsize\ttfamily,style=mystyle}
 


### PR DESCRIPTION
Hello!
thanks for sharing this template, it's very elegant and handy.
I found that it can be used also to take notes in real time, and for this purpose I added two short commands:
`\beq` which stands for `\begin{equation}` and `\eeq` for `\end{equation}` (there are also `\bequ` and `\eequ` for `\begin{equation*}` and `\end{equation*}`, respectively).

